### PR TITLE
fix crash on forge 41.0.94+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.19-41.0.38'
+    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency

--- a/src/main/java/com/charles445/damagetilt/EventHandler.java
+++ b/src/main/java/com/charles445/damagetilt/EventHandler.java
@@ -27,9 +27,9 @@ public class EventHandler
 		if(!TiltConfig.damageTiltEnabled)
 			return;
 		
-		if(event.getEntityLiving() instanceof Player)
+		if(event.getEntity() instanceof Player)
 		{
-			Player player = (Player) event.getEntityLiving();
+			Player player = (Player) event.getEntity();
 			if(player.level.isClientSide)
 				return;
 			

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,7 +14,7 @@ Tilts the player's camera when they take damage
 [[dependencies.damagetilt]]
 modId="forge"
 mandatory=true
-versionRange="[41,)"
+versionRange="[41.0.94,)"
 ordering="NONE"
 side="BOTH"
    


### PR DESCRIPTION
forge 41.0.94 renamed some things, which made the mod crash on that and any newer forge versions. ([log](https://gist.github.com/adrianmgg/2bbb24dbd039a6be217da47986adb351#file-damagetilt-1-19-forge-0-1-1-jar-debug-log-L1080-L1148))

this pr:
- upgrades forge to 41.1.0
- updates things that were renamed in 41.0.94
- changes minimum forge version in mods.toml to 41.0.94